### PR TITLE
file prefix blacklist

### DIFF
--- a/src/pattypan/Util.java
+++ b/src/pattypan/Util.java
@@ -129,8 +129,19 @@ public final class Util {
                   "tif", "wav", "webm", "webp", "xcf")
   );
 
+  // https://commons.wikimedia.org/wiki/MediaWiki:Filename-prefix-blacklist
+  private final static ArrayList<String> filenamePrefixBlacklist = new ArrayList<>(
+    Arrays.asList("CIMG", "DSC_", "DSCF", "DSCN", "DUW", "GEDC",
+            "IMG", "JD", "MGP", "PICT", "Imagen", "FOTO", "DSC",
+            "SANY", "SAM")
+  );
+
   public static boolean stringHasValidFileExtension(String string) {
     return allowedExtentionImage.parallelStream().anyMatch(string::endsWith);
+  }
+
+  public static boolean isPossibleBadFilename(String name) {
+    return filenamePrefixBlacklist.parallelStream().anyMatch(name::startsWith);
   }
 
   public static String getNameFromFilename(String filename) {

--- a/src/pattypan/panes/LoadPane.java
+++ b/src/pattypan/panes/LoadPane.java
@@ -172,6 +172,10 @@ public class LoadPane extends WikiPane {
           }
         }
 
+        if (Util.isPossibleBadFilename(description.get("name"))) {
+          warnings.add(description.get("name") + ": filename shouldn't have name from camera (DSC, DSCF, etc");
+        }
+
         Set<String> keys = Util.getKeysByValue(description, "");
         if (keys.size() > 0) {
           String values = keys.toString();


### PR DESCRIPTION
Adds a warning at the load-pane if the filename starts with a prefix in the filename-prefix-blacklist.