### PR TITLE
Give the wikicode pane a dynamic height

### DIFF
--- a/src/pattypan/elements/WikiScrollPane.java
+++ b/src/pattypan/elements/WikiScrollPane.java
@@ -31,9 +31,8 @@ public class WikiScrollPane extends ScrollPane {
   public WikiScrollPane(Node content) {
     this.setFitToWidth(true);
     this.setContent(content);
-    this.setPrefHeight(600);
   }
-  
+
   public WikiScrollPane setWidth(int width) {
     this.setMaxWidth(width);
     this.setMinWidth(width);

--- a/src/pattypan/panes/ChooseColumnsPane.java
+++ b/src/pattypan/panes/ChooseColumnsPane.java
@@ -23,6 +23,7 @@
  */
 package pattypan.panes;
 
+import java.util.logging.Level;
 import javafx.event.Event;
 import javafx.scene.Node;
 import javafx.scene.control.ComboBox;
@@ -165,9 +166,14 @@ public class ChooseColumnsPane extends WikiPane {
     });
 
     wikicodeText.getStyleClass().add("mw-ui-input");
-    wikicodeText.setMinHeight(250);
+    wikicodeText.setPrefHeight(this.stage.getHeight() - 350);
     wikicodeText.setText(Session.WIKICODE);
     wikicodePane.getChildren().addAll(templateBox, wikicodeText);
+
+    this.stage.heightProperty().addListener((obs, oldVal, newVal) -> {
+      wikicodeText.setPrefHeight(this.stage.getHeight() - 350);
+    });
+
     return this;
   }
 


### PR DESCRIPTION
I have yet to test if removing `this.setPrefHeight(600);` could have resulted in any GUI issues outside of the Choose Columns Pane.

Update it seams to be an good experience.