### PR TITLE
clear scenes in navigation step

### DIFF
--- a/src/pattypan/elements/WikiButton.java
+++ b/src/pattypan/elements/WikiButton.java
@@ -84,22 +84,23 @@ public class WikiButton extends Button {
 
   public WikiButton linkTo(String paneName, Stage stage) {
     this.setOnAction((ActionEvent event) -> {
-      goTo(paneName, stage);
+      goTo(paneName, stage, false);
     });
     return this;
   }
   
   public WikiButton linkTo(String paneName, Stage stage, boolean clearScenes) {
     this.setOnAction((ActionEvent event) -> {
-      if(clearScenes) {
-        Session.SCENES = new HashMap<>();
-      }
-      goTo(paneName, stage);
+      goTo(paneName, stage, clearScenes);
     });
     return this;
   }
   
-  public void goTo(String paneName, Stage stage) {
+  public void goTo(String paneName, Stage stage, boolean clearScenes) {
+    if (clearScenes) {
+      Session.SCENES = new HashMap<>();
+    }
+
     Scene scene = Session.SCENES.containsKey(paneName)
             ? Session.SCENES.get(paneName)
             : new Scene(getPaneByPaneName(paneName, stage), Util.WINDOW_WIDTH, Util.WINDOW_HEIGHT);

--- a/src/pattypan/panes/ChooseColumnsPane.java
+++ b/src/pattypan/panes/ChooseColumnsPane.java
@@ -103,7 +103,7 @@ public class ChooseColumnsPane extends WikiPane {
         }
       }
 
-      nextButton.goTo("CreateFilePane", stage);
+      nextButton.goTo("CreateFilePane", stage, true);
     });
     showTemplateFields(Session.TEMPLATE);
     return this;


### PR DESCRIPTION
This fixes an issue causing the Create File View summary to not being updated when creating multiple spreadsheets from different directories without exiting Pattypan.