### PR TITLE
replace deprecated FontLoader.computeStringWidth

### DIFF
--- a/src/pattypan/elements/WikiLabel.java
+++ b/src/pattypan/elements/WikiLabel.java
@@ -27,6 +27,7 @@ import com.sun.javafx.tk.FontLoader;
 import com.sun.javafx.tk.Toolkit;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
+import javafx.scene.text.Text;
 import javafx.scene.text.TextAlignment;
 import pattypan.Util;
 
@@ -63,8 +64,9 @@ public class WikiLabel extends Label {
   }
   
   public WikiLabel setTranslateByHalf(boolean right) {
-    FontLoader fontLoader = Toolkit.getToolkit().getFontLoader();
-    double textWidth = fontLoader.computeStringWidth(this.getText(), this.getFont());
+    Text text = new Text(this.getText());
+    text.setFont(this.getFont());
+    double textWidth = text.getBoundsInLocal().getWidth();
     this.setTranslateX(textWidth * 0.5 * (right ? 1 : -1));
     return this;
   }


### PR DESCRIPTION
FontLoader.computeStringWidth is deprecated and even removed in recent versions of javafx/openjfx causing Pattypan not to build.