### PR TITLE
add error if file name contains common invalid characters

### DIFF
--- a/src/pattypan/Util.java
+++ b/src/pattypan/Util.java
@@ -149,12 +149,22 @@ public final class Util {
             "SANY", "SAM")
   );
 
-  public static boolean stringHasValidFileExtension(String string) {
+  // https://www.mediawiki.org/wiki/Manual:Page_title
+  private final static ArrayList<String> invalidFilenameCharacters = new ArrayList<>(
+    Arrays.asList("#", "<", ">", "[", "]", "|", "{", "}")
+  );
+
+
+  public static boolean hasValidFileExtension(String string) {
     return allowedFileExtension.parallelStream().anyMatch(string::endsWith);
   }
 
-  public static boolean isPossibleBadFilename(String name) {
+  public static boolean hasPossibleBadFilenamePrefix(String name) {
     return filenamePrefixBlacklist.parallelStream().anyMatch(name::startsWith);
+  }
+
+  public static boolean hasInvalidFilenameCharacters(String name) {
+    return invalidFilenameCharacters.parallelStream().anyMatch(name::contains);
   }
 
   public static String getNameFromFilename(String filename) {

--- a/src/pattypan/panes/LoadPane.java
+++ b/src/pattypan/panes/LoadPane.java
@@ -163,7 +163,7 @@ public class LoadPane extends WikiPane {
           }
 
           // when uploaded from URL the extension is not automatically added
-          if (!Util.stringHasValidFileExtension(description.get("name"))) {
+          if (!Util.hasValidFileExtension(description.get("name"))) {
             throw new Exception("filename does not include a valid file extension");
           }
         } else {
@@ -172,8 +172,12 @@ public class LoadPane extends WikiPane {
           }
         }
 
-        if (Util.isPossibleBadFilename(description.get("name"))) {
-          warnings.add(description.get("name") + ": filename shouldn't have name from camera (DSC, DSCF, etc");
+        if (Util.hasPossibleBadFilenamePrefix(description.get("name"))) {
+          warnings.add(description.get("name") + ": filename shouldn't have name from camera (DSC, DSCF, etc)");
+        }
+
+        if (Util.hasInvalidFilenameCharacters(description.get("name"))) {
+          throw new Exception(description.get("name") + ": filename shouldn't contain invalid characters (#, ], {, etc)");
         }
 
         Set<String> keys = Util.getKeysByValue(description, "");


### PR DESCRIPTION
This adds another basic check to filenames. Not all invalid characters are included but the most commons ones. At one time the error endpoint should be implemented to solve this and other filename issues. 

Related: #113 #69 etc